### PR TITLE
Feature 주식 검색 찜하기 구현

### DIFF
--- a/client/src/app/(protected)/home/HomeView/HomeView.tsx
+++ b/client/src/app/(protected)/home/HomeView/HomeView.tsx
@@ -82,7 +82,7 @@ export function HomeView() {
                 rank: index + 1,
                 stockCode: item.code,
                 stockName: item.name,
-                price: formatPrice(item.price.toString()),
+                price: formatPrice(item.price.toString(), item.exchangeCode),
                 change: formatChange(item.change),
                 changePercentage: formatPercentage(item.changeRate.toString()),
                 isPositiveChange:

--- a/client/src/app/(protected)/mypage/MyPageView.tsx
+++ b/client/src/app/(protected)/mypage/MyPageView.tsx
@@ -56,7 +56,6 @@ export function MyPageView() {
         }
 
         const data: ApiResponse = await response.json();
-
         if (data.resultCode === '0' && Array.isArray(data.stocks)) {
           if (data.stocks.length === 0) {
             setFavoriteStocks([]);
@@ -68,15 +67,14 @@ export function MyPageView() {
               rank: index + 1,
               stockCode: item.code,
               stockName: item.name,
-              price: formatPrice(item.price.toString()),
+              price: formatPrice(item.price.toString(), item.exchangeCode),
               change: formatChange(item.change),
+              exchangeCode: item.exchangeCode,
               changePercentage: formatPercentage(item.changeRate.toString()),
               isPositiveChange: formatPositiveChange(item.change),
               isFavorite: true,
             }),
           );
-          console.log(transformedData);
-
           setFavoriteStocks(transformedData);
         } else {
           throw new Error('데이터 형식 오류');

--- a/client/src/app/components/StockListItem/StockListItem.tsx
+++ b/client/src/app/components/StockListItem/StockListItem.tsx
@@ -53,7 +53,7 @@ export function StockListItem({
         .then((isLiked) => setFavorite(isLiked))
         .catch((err) => console.error('좋아요 상태 조회 실패:', err));
     }
-  }, [stockCode]);
+  }, [stockCode, email]);
   const handleFavoriteClick = () => {
     if (!email) {
       alert('로그인이 필요합니다.');

--- a/client/src/app/components/StockListItem/StockListItem.tsx
+++ b/client/src/app/components/StockListItem/StockListItem.tsx
@@ -69,12 +69,16 @@ export function StockListItem({
         ? 'http://localhost:8080/api/likes/remove'
         : 'http://localhost:8080/api/likes/add';
 
+      let exchangeCode = 'KRX';
+      if (stockCode.match(/[A-Z]/)) {
+        exchangeCode = 'NAS'; // 기본 해외거래소는 나스닥으로 가정
+      }
       const response = await fetch(url, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ email, stockCode }),
+        body: JSON.stringify({ email, stockCode, stockName, exchangeCode }),
       });
 
       if (response.ok) {

--- a/client/src/app/types/index.ts
+++ b/client/src/app/types/index.ts
@@ -13,6 +13,7 @@ export interface StockData {
   price: number;
   change: string;
   changeRate: number;
+  exchangeCode: string;
   isPositiveChange?: boolean;
 }
 

--- a/client/src/app/types/stock.ts
+++ b/client/src/app/types/stock.ts
@@ -18,7 +18,6 @@ export interface BaseStock {
   // 표시 속성
   rank?: number; // 순위
   logoType?: 'tesla' | 'etf' | 'kodex' | 'inverse' | 'normal' | string;
-
   // 추가 메타데이터
   country?: 'us' | 'kr' | string;
   leverage?: string; // 레버리지 ETF 표시용

--- a/client/src/app/utils/formatters.ts
+++ b/client/src/app/utils/formatters.ts
@@ -1,6 +1,9 @@
-export function formatPrice(price: string) {
+export function formatPrice(price: string, exchangeCode: string) {
   if (!price) return '0원';
   const numericPrice = price.replace(/[^\d.-]/g, '');
+  if (exchangeCode !== 'KRX') {
+    return `${parseInt(numericPrice).toLocaleString()}$`;
+  }
   return `${parseInt(numericPrice).toLocaleString()}원`;
 }
 

--- a/server/src/main/java/com/shop/cafe/controller/LikeController.java
+++ b/server/src/main/java/com/shop/cafe/controller/LikeController.java
@@ -2,6 +2,7 @@ package com.shop.cafe.controller;
 
 import com.shop.cafe.dto.Like;
 import com.shop.cafe.dto.StockApiResponse;
+import com.shop.cafe.dto.StockCodeName;
 import com.shop.cafe.dto.StockInfo;
 import com.shop.cafe.service.LikeService;
 import com.shop.cafe.service.StockService;
@@ -28,6 +29,12 @@ public class LikeController {
     @PostMapping("/add")
     public ResponseEntity<String> addLike(@RequestBody Like like) {
         try {
+            // 거래소 코드가 없으면 코드 패턴으로 추측
+            if (like.getExchangeCode() == null || like.getExchangeCode().isEmpty()) {
+                String exchangeCode = like.getStockCode().matches("^[0-9]+$") ? "KRX" : "NAS";
+                like.setExchangeCode(exchangeCode);
+            }
+            
             likeService.addLike(like);
             return ResponseEntity.ok("좋아요가 추가되었습니다.");
         } catch (Exception e) {
@@ -35,7 +42,6 @@ public class LikeController {
             return ResponseEntity.internalServerError().body("좋아요 추가 실패");
         }
     }
-
     @GetMapping("/stocks")
     public ResponseEntity<StockApiResponse> getFavoriteStocks(@RequestParam String email) {
         try {
@@ -46,13 +52,17 @@ public class LikeController {
                 return ResponseEntity.ok(new StockApiResponse("0", "좋아요한 종목이 없습니다.", new ArrayList<>()));
             }
             
-            // 2. 좋아요 목록에서 주식 코드만 추출
-            List<String> stockCodes = favoritesList.stream()
-                .map(item -> item.get("stock_code"))
+            // 2. 좋아요 목록에서 코드, 종목명, 거래소 정보 추출
+            List<StockCodeName> stockCodeNames = favoritesList.stream()
+                .map(item -> new StockCodeName(
+                    item.get("stock_code"),
+                    item.get("stock_name"),
+                    item.get("exchange_code") // 거래소 코드 추가
+                ))
                 .collect(Collectors.toList());
             
-            // 3. 주식 코드 목록으로 주식 정보 가져오기
-            List<StockInfo> stocks = stockService.getStocksByCodeList(stockCodes);
+            // 3. stockService의 getStocksByCodeNameList 메서드 사용
+            List<StockInfo> stocks = stockService.getStocksByCodeNameList(stockCodeNames);
             
             // 4. 결과 반환
             StockApiResponse response = new StockApiResponse("0", "성공", stocks);
@@ -63,6 +73,7 @@ public class LikeController {
                 .body(new StockApiResponse("9999", "오류 발생: " + e.getMessage(), null));
         }
     }
+    
     @PostMapping("/remove")
     public ResponseEntity<String> removeLike(@RequestBody Like like) {
         try {

--- a/server/src/main/java/com/shop/cafe/dao/LikeDao.java
+++ b/server/src/main/java/com/shop/cafe/dao/LikeDao.java
@@ -4,8 +4,6 @@ import com.shop.cafe.dto.Like;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Repository;
 
-import java.sql.ResultSet;
-import java.sql.SQLException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -19,8 +17,8 @@ public class LikeDao {
     }
 
     public void addLike(Like like) {
-        String sql = "INSERT INTO likes (email, stock_code) VALUES (?, ?)";
-        jdbcTemplate.update(sql, like.getEmail(), like.getStockCode());
+        String sql = "INSERT INTO likes (email, stock_code, stock_name, exchange_code) VALUES (?, ?, ?, ?)";
+        jdbcTemplate.update(sql, like.getEmail(), like.getStockCode(), like.getStockName(), like.getExchangeCode());
     }
 
     public void removeLike(Like like) {
@@ -33,12 +31,14 @@ public class LikeDao {
         Integer count = jdbcTemplate.queryForObject(sql, Integer.class, email, stockCode);
         return count != null && count > 0;
     }
-    
+
     public List<Map<String, String>> getLikedStocks(String email) {
-        String sql = "SELECT stock_code FROM likes WHERE email = ?";
+        String sql = "SELECT stock_code, stock_name, exchange_code FROM likes WHERE email = ?";
         return jdbcTemplate.query(sql, (rs, rowNum) -> {
             Map<String, String> map = new HashMap<>();
             map.put("stock_code", rs.getString("stock_code"));
+            map.put("stock_name", rs.getString("stock_name"));
+            map.put("exchange_code", rs.getString("exchange_code"));
             return map;
         }, email);
     }

--- a/server/src/main/java/com/shop/cafe/dao/StockDao.java
+++ b/server/src/main/java/com/shop/cafe/dao/StockDao.java
@@ -37,7 +37,16 @@ public class StockDao {
         stocksMap.put(category, new ArrayList<>(stocks));
         lastUpdatedMap.put(category, LocalDateTime.now());
     }
-
+ // 개별 주식 정보 저장
+    public void saveStockInfo(String code, StockInfo stockInfo) {
+        // 임시 맵 생성
+        List<StockInfo> singleStockList = new ArrayList<>();
+        singleStockList.add(stockInfo);
+        
+        // 해당 코드에 대한 정보만 저장하는 맵 생성
+        stocksMap.put("STOCK_" + code, singleStockList);
+        lastUpdatedMap.put("STOCK_" + code, LocalDateTime.now());
+    }
     // 국내 주식 정보 조회
     public List<StockInfo> getDomesticStocks() {
         return stocksMap.getOrDefault(DOMESTIC_KEY, new ArrayList<>());

--- a/server/src/main/java/com/shop/cafe/dto/Like.java
+++ b/server/src/main/java/com/shop/cafe/dto/Like.java
@@ -1,37 +1,20 @@
 package com.shop.cafe.dto;
 
-public class Like{
+public class Like {
     private String email;
     private String stockCode;
-
-    public Like() {
-        super();
-    }
-
-    public Like(String email, String stockCode) {
-        super();
-        this.email = email;
-        this.stockCode = stockCode;
-    }
-
-    public String getEmail() {
-        return email;
-    }
-
-    public void setEmail(String email) {
-        this.email = email;
-    }
-
-    public String getStockCode() {
-        return stockCode;
-    }
-
-    public void setStockCode(String stockCode) {
-        this.stockCode = stockCode;
-    }
-
-    @Override
-    public String toString() {
-        return "LikeDTO [email=" + email + ", stockCode=" + stockCode + "]";
-    }
+    private String stockName;
+    private String exchangeCode; // 추가된 필드
+    
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+    
+    public String getStockCode() { return stockCode; }
+    public void setStockCode(String stockCode) { this.stockCode = stockCode; }
+    
+    public String getStockName() { return stockName; }
+    public void setStockName(String stockName) { this.stockName = stockName; }
+    
+    public String getExchangeCode() { return exchangeCode; }
+    public void setExchangeCode(String exchangeCode) { this.exchangeCode = exchangeCode; }
 }

--- a/server/src/main/java/com/shop/cafe/dto/StockCodeName.java
+++ b/server/src/main/java/com/shop/cafe/dto/StockCodeName.java
@@ -1,0 +1,27 @@
+package com.shop.cafe.dto;
+
+public class StockCodeName {
+    private String code;
+    private String name;
+    private String exchangeCode; // 추가된 필드
+    
+    public StockCodeName(String code, String name, String exchangeCode) {
+        this.code = code;
+        this.name = name;
+        this.exchangeCode = exchangeCode;
+    }
+    
+    public String getCode() { return code; }
+    public String getName() { return name; }
+    public String getExchangeCode() { return exchangeCode; }
+    
+    // 거래소 코드가 비어있을 경우를 대비한 유틸리티 메서드
+    public String getEffectiveExchangeCode() {
+        if (exchangeCode != null && !exchangeCode.isEmpty()) {
+            return exchangeCode;
+        }
+        
+        // 코드 패턴으로 추측
+        return code.matches("^[0-9]+$") ? "KRX" : "NAS";
+    }
+}


### PR DESCRIPTION
## 📝 변경 사항
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [x] 빌드 부분 혹은 패키지 매니저 수정
- [x] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
- [ ] 기타

## 🔍 변경 사항 세부 설명

- #39 
- 검색뷰 에서 주식 검색 후 클릭하면 찜하기 등록하도록 연동
- 찜하기에 등록된 주식은 종목코드, 거래소명, 종목명을 DB에 저장하도록 컬럼 추가 (종목명,거래소)
```sql
ALTER TABLE ureca.likes ADD COLUMN exchange_code VARCHAR(10);
ALTER TABLE ureca.likes ADD COLUMN stock_name VARCHAR(100);
```
- 한국, 미국 거래소별 정보 가져오도록 분리 (domestic, overseas)

## 📷 스크린샷 (선택)


https://github.com/user-attachments/assets/9c708887-9cff-45b5-b602-a759d94a8bcc


## ✅ 작성자 체크리스트

- [x] Self-review: commit 이나 오타 없이 코드가 스스로 검토됨
- [x] 로컬에서 모든 기능이 정상 작동함(버그수정 /기능에 대한 테스트)
- [x] 린터 및 포맷터로 코드 정리됨